### PR TITLE
Wye serializers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ cover/
 local_settings.py
 db.sqlite3
 db.sqlite3-journal
+static/
 
 # PEP 582; used by e.g. github.com/David-OConnor/pyflow and github.com/pdm-project/pdm
 __pypackages__/
@@ -42,3 +43,8 @@ venv.bak/
 # custom
 media/
 .vscode
+wye_serializers.egg-info/
+
+# build
+build
+dist

--- a/wye/serializers/__init__.py
+++ b/wye/serializers/__init__.py
@@ -1,0 +1,9 @@
+from wye.serializers.serializer import (
+	Serializer, BaseSerializer
+)
+
+
+__all__ = [
+	"BaseSerializer",
+	"Serializer"
+]

--- a/wye/serializers/fields.py
+++ b/wye/serializers/fields.py
@@ -1,0 +1,38 @@
+from typing import (
+	Any, Dict, Optional
+)
+
+
+class BaseField:
+	__type__ = None
+
+	def __init__(
+		self,
+		alias: Optional[str] = None
+	) -> None:
+		self.alias = alias
+
+	def _build_rules(self) -> Dict[str, Any]:
+		obj = {}
+		obj["TYPE"] = self.__type__
+		obj["ALIAS"] = self.alias
+
+		return obj
+
+	def __call__(self) -> Any:
+		return self._build_rules()
+
+	def __repr__(self) -> str:
+		return f"Field <{self.__class__.__name__}> type:{self.__type__}"
+
+
+class INT(BaseField):
+	__type__ = int
+
+
+class STR(BaseField):
+	__type__ = str
+
+
+class FLOAT(BaseField):
+	__type__ = float

--- a/wye/serializers/fields.py
+++ b/wye/serializers/fields.py
@@ -36,3 +36,7 @@ class STR(BaseField):
 
 class FLOAT(BaseField):
 	__type__ = float
+
+
+class BOOL(BaseField):
+	__type__ = bool

--- a/wye/serializers/serializer.py
+++ b/wye/serializers/serializer.py
@@ -1,0 +1,22 @@
+from typing import (
+	Any, Dict
+)
+
+
+class BaseSerializer:
+	def __init__(self) -> None:
+		self._build_rules()
+
+	def _build_rules(self) -> Dict[str, Any]:
+		rules = {}
+		for param, type_ in self.__annotations__.items():
+			rules[param] = self.__class__.__dict__[param]()
+		return rules
+
+	def __call__(self) -> Any:
+		return self._build_rules()
+
+
+class Serializer(BaseSerializer):
+	def __init__(self, *args, **kwargs) -> None:
+		super().__init__(*args, **kwargs)

--- a/wye/serializers/setup.py
+++ b/wye/serializers/setup.py
@@ -1,0 +1,25 @@
+from distutils.core import (
+    setup, Extension
+)
+
+
+def main():
+    setup(
+		name = "wye_serializers",
+        version = "1.0.0",
+        description = "Python interface for the Wye",
+        author = "Test Test",
+        author_email = "test@gmail.com",
+        ext_modules = [
+			Extension(
+                "wye_serializers",
+                [".\\wye\\serializers\\src\\core\\core.c"],
+                include_dirs = ['.\\wye\\serializers\\src\\']
+            )
+		],
+		package_dir = {"": "wye"}
+	)
+
+
+if __name__ == "__main__":
+    main()

--- a/wye/serializers/src/core/constant.h
+++ b/wye/serializers/src/core/constant.h
@@ -1,2 +1,6 @@
+void *SetValidationError();
+void *SetAttributeError();
+static PyObject *method_build_json(PyObject *self, PyObject *args);
+
 #define TYPE_FIELD_KEY "TYPE"
 #define ALIAS_FIELD_KEY "ALIAS"

--- a/wye/serializers/src/core/constant.h
+++ b/wye/serializers/src/core/constant.h
@@ -1,0 +1,2 @@
+#define TYPE_FIELD_KEY "TYPE"
+#define ALIAS_FIELD_KEY "ALIAS"

--- a/wye/serializers/src/core/core.c
+++ b/wye/serializers/src/core/core.c
@@ -1,19 +1,46 @@
+#define PY_SSIZE_T_CLEAN
+
 #include <Python.h>
-#include <core\constant.h>
+#include <core/constant.h>
+
+
+void *SetValidationError() {
+    PyErr_SetString(PyExc_TypeError, "<WyeSerializers>: Validation error");
+    return NULL;
+}
+
+void *SetAttributeError() {
+    PyErr_SetString(PyExc_AttributeError, "<WyeSerializers>: Missing required parameters");
+    return NULL;
+}
 
 
 static PyObject *method_build_json(PyObject *self, PyObject *args) {
     PyObject *obj = PyDict_New();
-    char *value = NULL;
-    const char *key;
+    PyObject *json, *rules = NULL;
 
-    if(!PyArg_ParseTuple(args, "ss", &key, &value)) {
+    if (!PyArg_ParseTuple(args, "OO", &json, &rules)) {
         return NULL;
     }
 
-    PyObject *PyValue = PyUnicode_FromString(value);
+    PyObject *params_rules = PyDict_Keys(rules);
+    for (int index_param_rule = 0; index_param_rule < PyList_Size(params_rules); index_param_rule++) {
+        PyObject *param_title = PyList_GetItem(params_rules, index_param_rule);
+        PyObject *param_rule = PyDict_GetItem(rules, param_title);
 
-    PyDict_SetItemString(obj, key, PyValue);
+        PyObject *type = PyDict_GetItemString(param_rule, TYPE_FIELD_KEY);
+        PyObject *json_field = PyDict_GetItem(json, param_title);
+        if (!json_field) {
+            return SetAttributeError();
+        }
+        if (!PyObject_IsInstance(json_field, type)) {
+            return SetValidationError();
+        }
+
+        PyObject *alias = PyDict_GetItemString(param_rule, ALIAS_FIELD_KEY);
+
+        PyDict_SetItem(obj, alias, json_field);
+    }
 
     return obj;
 }
@@ -24,21 +51,16 @@ static PyMethodDef WyeSerializersMethods[] = {
         "build_json",
         method_build_json,
         METH_VARARGS,
-        "Python interface for fputs Wye"
+        "Collects json according to the rules"
     },
-    {
-        NULL,
-        NULL,
-        0,
-        NULL
-    }
+    { NULL, NULL, 0, NULL }
 };
 
 
 static struct PyModuleDef wye_serializers_modules = {
     PyModuleDef_HEAD_INIT,
     "wye_serializers",
-    "Python interface for the Wye",
+    "Python serializer interface for Wye",
     -1,
     WyeSerializersMethods
 };

--- a/wye/serializers/src/core/core.c
+++ b/wye/serializers/src/core/core.c
@@ -1,0 +1,50 @@
+#include <Python.h>
+#include <core\constant.h>
+
+
+static PyObject *method_build_json(PyObject *self, PyObject *args) {
+    PyObject *obj = PyDict_New();
+    char *value = NULL;
+    const char *key;
+
+    if(!PyArg_ParseTuple(args, "ss", &key, &value)) {
+        return NULL;
+    }
+
+    PyObject *PyValue = PyUnicode_FromString(value);
+
+    PyDict_SetItemString(obj, key, PyValue);
+
+    return obj;
+}
+
+
+static PyMethodDef WyeSerializersMethods[] = {
+    {
+        "build_json",
+        method_build_json,
+        METH_VARARGS,
+        "Python interface for fputs Wye"
+    },
+    {
+        NULL,
+        NULL,
+        0,
+        NULL
+    }
+};
+
+
+static struct PyModuleDef wye_serializers_modules = {
+    PyModuleDef_HEAD_INIT,
+    "wye_serializers",
+    "Python interface for the Wye",
+    -1,
+    WyeSerializersMethods
+};
+
+
+PyMODINIT_FUNC PyInit_wye_serializers(void) {
+    PyObject *module = PyModule_Create(&wye_serializers_modules);
+    return module;
+}


### PR DESCRIPTION
Для установки сериализатора выполнить следующую команду:

- Linux
  ```bash
  python wye/serializers/setup.py install
  ```
- Windows
  ```bash
  python wye\serializers\setup.py install
  ```

Example:
```python
from wye.serializers import Serializer
from wye.serializers import fields
import wye_serializers


class Serializer_1(Serializer):
    param_1: int = fields.INT(alias = "param1")
    param_2: str = fields.STR(alias = "param2")
    param_3: float = fields.FLOAT(alias = "param3")
    param_4: bool = fields.BOOL(alias = "param4")


wye_serializers.build_json({
    "param_1": 1,
    "param_2": "value",
    "param_3": 1.5,
    "param_4": True
}, serializer()) # > {'param1': 1, 'param2': 'value', 'param3': 1.5, 'param4': True}
```

На данный момент сериализатор умеет работать с примитивными типами - `int`, `str`, `float` и `bool`

Методы:
- `build_json(json, rules)` - Собирает json по правилам. Принимает: `json: Dict[str, Union[str, bool, float, int]]`, `rules: Serializer`. Возвращает `Dict[str, Any]`