### PR TITLE
Wye serializers

### DIFF
--- a/wye/serializers/fields.py
+++ b/wye/serializers/fields.py
@@ -5,6 +5,8 @@ from typing import (
 
 ALIAS = "ALIAS"
 TYPE = "TYPE"
+DEFAULT = "DEFAULT"
+REQUIRED = "REQUIRED"
 
 
 class BaseField:
@@ -12,19 +14,28 @@ class BaseField:
 
 	def __init__(
 		self,
+		default: Any = None,
 		alias: Optional[str] = None
 	) -> None:
+		self._default = default
 		self._alias = alias
+		self._required = True
 
 	def _build_rules(self) -> Dict[str, Any]:
-		obj = {}
-		obj[TYPE] = self.__type__
-		obj[ALIAS] = self._alias
+		rules = {}
+		rules[TYPE] = self.__type__
+		rules[ALIAS] = self._alias
+		rules[DEFAULT] = self._default
+		rules[REQUIRED] = self._required
 
-		return obj
+		return rules
 
 	@property
-	def alias(self):
+	def default(self) -> Any:
+		return self._default
+
+	@property
+	def alias(self) -> str:
 		return self._alias
 
 	@alias.setter
@@ -32,6 +43,14 @@ class BaseField:
 		if not value:
 			raise ValueError("No 'alias'")
 		self._alias = value
+
+	@property
+	def required(self) -> bool:
+		return self._required
+
+	@required.setter
+	def required(self, value: bool):
+		self._required = value
 
 	def __call__(self) -> Any:
 		return self._build_rules()

--- a/wye/serializers/serializer.py
+++ b/wye/serializers/serializer.py
@@ -1,24 +1,43 @@
+from types import NoneType
 from typing import (
-	Any, Dict
+	get_args, get_origin, Dict,
+	Any, Union
 )
 
-from wye.serializers.fields import ALIAS
+from wye.serializers.fields import (
+	ALIAS, REQUIRED
+)
 
 
 class BaseSerializer:
 	def __init__(self) -> None:
-		self._build_rules()
+		self._rules = self._build_rules()
 
 	def _build_rules(self) -> Dict[str, Any]:
 		rules = {}
+
 		for param, type_ in self.__annotations__.items():
 			rules[param] = self.__class__.__dict__[param]()
 			if not rules[param][ALIAS]:
 				rules[param][ALIAS] = param
+			self.__set_required_field(rules[param], type_)
+
 		return rules
 
-	def __call__(self) -> Any:
-		return self._build_rules()
+	def __set_required_field(
+		self,
+		rules_one_field: Dict[str, Any],
+		type_field: Any
+	) -> None:
+		if get_origin(type_field) is Union:
+			for type_ in get_args(type_field):
+				if type_ == NoneType:
+					new_rule = {}
+					new_rule[REQUIRED] = False
+					rules_one_field.update(new_rule)
+
+	def __call__(self) -> Dict[str, Any]:
+		return self._rules
 
 
 class Serializer(BaseSerializer):

--- a/wye/serializers/serializer.py
+++ b/wye/serializers/serializer.py
@@ -1,4 +1,3 @@
-from types import NoneType
 from typing import (
 	get_args, get_origin, Dict,
 	Any, Union
@@ -7,6 +6,9 @@ from typing import (
 from wye.serializers.fields import (
 	ALIAS, REQUIRED
 )
+
+
+NoneType = type(None)
 
 
 class BaseSerializer:

--- a/wye/serializers/setup.py
+++ b/wye/serializers/setup.py
@@ -8,13 +8,11 @@ def main():
 		name = "wye_serializers",
         version = "1.0.0",
         description = "Python interface for the Wye",
-        author = "Test Test",
-        author_email = "test@gmail.com",
         ext_modules = [
 			Extension(
                 "wye_serializers",
-                [".\\wye\\serializers\\src\\core\\core.c"],
-                include_dirs = ['.\\wye\\serializers\\src\\']
+                ["./wye/serializers/src/core/core.c"],
+                include_dirs = ['./wye/serializers/src/']
             )
 		],
 		package_dir = {"": "wye"}

--- a/wye/serializers/src/core/constant.h
+++ b/wye/serializers/src/core/constant.h
@@ -1,6 +1,10 @@
-void *SetValidationError();
-void *SetAttributeError();
+int SetValidationError();
+int SetAttributeError();
+void *SetDefaultValue(PyObject *json, PyObject *rules);
+int CheckField(PyObject *json_field, PyObject *type, PyObject *is_required);
 static PyObject *method_build_json(PyObject *self, PyObject *args);
 
 #define TYPE_FIELD_KEY "TYPE"
 #define ALIAS_FIELD_KEY "ALIAS"
+#define DEFAULT_FIELD_KEY "DEFAULT"
+#define REQUIRED_FIELD_KEY "REQUIRED"

--- a/wye/serializers/src/core/constant.h
+++ b/wye/serializers/src/core/constant.h
@@ -1,6 +1,6 @@
 int SetValidationError();
 int SetAttributeError();
-void *SetDefaultValue(PyObject *json, PyObject *rules);
+void *SetDefaultValue(PyObject *obj, PyObject *rules, PyObject *param_title);
 int CheckField(PyObject *json_field, PyObject *type, PyObject *is_required);
 static PyObject *method_build_json(PyObject *self, PyObject *args);
 


### PR DESCRIPTION
Example:
```python
import typing

from wye.serializers import Serializer
from wye.serializers import fields
import wye_serializers


class Serializer_1(Serializer):
    param_1: typing.Optional[int] = fields.INT(default = 10, alias = "param1")
    param_2: str = fields.STR(default = "value", alias = "param2")
    param_3: float = fields.FLOAT(alias = "param3")
    param_4: bool = fields.BOOL(alias = "param4")
```

1) Установка значения по дефолту - `fields.INT(default = 10, alias = "param1")`
2) Необязательный параметр - `param_1: typing.Optional[int]`