### PR TITLE
Wye serializers

### DIFF
--- a/wye/serializers/__init__.py
+++ b/wye/serializers/__init__.py
@@ -1,9 +1,11 @@
 from wye.serializers.serializer import (
 	Serializer, BaseSerializer
 )
+from wye.serializers.interlayer import build_json
 
 
 __all__ = [
 	"BaseSerializer",
-	"Serializer"
+	"Serializer",
+	"build_json"
 ]

--- a/wye/serializers/interlayer.py
+++ b/wye/serializers/interlayer.py
@@ -1,0 +1,14 @@
+from typing import (
+	Any, Dict, Type
+)
+
+from wye.serializers import BaseSerializer
+
+import wye_serializers
+
+
+def build_json(
+	json: Dict[str, Any],
+	rules: Type[BaseSerializer]
+) -> Dict[str, Any]:
+	return wye_serializers.build_json(json, rules())

--- a/wye/serializers/interlayer.py
+++ b/wye/serializers/interlayer.py
@@ -1,5 +1,6 @@
 from typing import (
-	Any, Dict, Type
+	Any, Dict, Type,
+	Union, List
 )
 
 from wye.serializers import BaseSerializer
@@ -8,7 +9,7 @@ import wye_serializers
 
 
 def build_json(
-	json: Dict[str, Any],
+	json: Union[Dict[str, Any], List[Dict[str, Any]]],
 	rules: Type[BaseSerializer]
-) -> Dict[str, Any]:
+) -> Union[Dict[str, Any], List[Dict[str, Any]]]:
 	return wye_serializers.build_json(json, rules())

--- a/wye/serializers/src/core/constant.h
+++ b/wye/serializers/src/core/constant.h
@@ -2,6 +2,9 @@ int SetValidationError();
 int SetAttributeError();
 void *SetDefaultValue(PyObject *obj, PyObject *rules, PyObject *param_title);
 int CheckField(PyObject *json_field, PyObject *type, PyObject *is_required);
+int BuildJson(
+    PyObject *obj, PyObject *json, PyObject *params_rules, PyObject *rules, int index_param_rule
+);
 static PyObject *method_build_json(PyObject *self, PyObject *args);
 
 #define TYPE_FIELD_KEY "TYPE"

--- a/wye/serializers/src/core/core.c
+++ b/wye/serializers/src/core/core.c
@@ -84,7 +84,9 @@ static PyObject *method_build_json(PyObject *self, PyObject *args) {
             PyObject *raw_json = PyList_GetItem(json, in_json);
 
             for (int index_param_rule = 0; index_param_rule < PyList_Size(params_rules); index_param_rule++) {
-                BuildJson(ready_json, raw_json, params_rules, rules, index_param_rule);
+                if (!BuildJson(ready_json, raw_json, params_rules, rules, index_param_rule)) {
+                    return NULL;
+                }
             }
 
             PyList_Append(list_json, ready_json);
@@ -95,7 +97,9 @@ static PyObject *method_build_json(PyObject *self, PyObject *args) {
 
     PyObject *obj = PyDict_New();
     for (int index_param_rule = 0; index_param_rule < PyList_Size(params_rules); index_param_rule++) {
-        BuildJson(obj, json, params_rules, rules, index_param_rule);
+        if (!BuildJson(obj, json, params_rules, rules, index_param_rule)) {
+            return NULL;
+        }
     }
 
     return obj;


### PR DESCRIPTION
В метод `build_json` теперь можно опрокидовать так словарь, так и список словарей:
```python
from typing import Optional

from wye.serializers import (
    Serializer, build_json
)
from wye.serializers import fields


class SerializerExample(Serializer):
    param_1: Optional[int] = fields.INT(default = 10, alias = "param1")
    param_2: str = fields.STR(alias = "param2")
    param_3: float = fields.FLOAT(alias = "param3")
    param_4: bool = fields.BOOL()


serializer = SerializerExample()
build_json([
    {
        "param_1": 1,
        "param_2": "value",
        "param_3": 1.1,
        "param_4": True
    },
    {
        "param_2": "value 2",
        "param_3": 1.5,
        "param_4": True
    }],
    serializer
)
```